### PR TITLE
Add "match" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ validator = Schash::Validator.new do
         root: string,
         allowed_ips: array_of(string),
       }),
+      listen: match(/^(80|443)$/),
     },
   }
 end
@@ -43,6 +44,7 @@ valid = {
       root: "/var/www/itamae",
       allowed_ips: ["127.0.0.1/32"],
     }],
+    listen: "80"
   },
 }
 
@@ -57,11 +59,12 @@ invalid = {
       root: "/var/www/itamae",
       allowed_ips: ["127.0.0.1/32"],
     },
+    listen: "8080"
   },
 }
 
 validator.validate(invalid)
-# => [#<struct Schash::Schema::Error position=["nginx", "user"], message="is not String">, #<struct Schash::Schema::Error position=["nginx", "sites"], message="is not an array">]
+# => [#<struct Schash::Schema::Error position=["nginx", "user"], message="is not String">, #<struct Schash::Schema::Error position=["nginx", "sites"], message="is not an array">, #<struct Schash::Schema::Error position=["nginx", "listen"], message="does not match /^(80|443)$/">]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/schash/fork )
+1. Fork it ( https://github.com/ryotarai/schash/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/schash/schema/dsl.rb
+++ b/lib/schash/schema/dsl.rb
@@ -48,6 +48,10 @@ module Schash
       def boolean
         one_of_types(TrueClass, FalseClass)
       end
+
+      def match(pattern)
+        Rule::Match.new(pattern)
+      end
     end
   end
 end

--- a/lib/schash/schema/rule.rb
+++ b/lib/schash/schema/rule.rb
@@ -4,4 +4,5 @@ require 'schash/schema/rule/one_of_types'
 require 'schash/schema/rule/hash'
 require 'schash/schema/rule/optional'
 require 'schash/schema/rule/type'
+require 'schash/schema/rule/match'
 

--- a/lib/schash/schema/rule/match.rb
+++ b/lib/schash/schema/rule/match.rb
@@ -1,0 +1,21 @@
+module Schash
+  module Schema
+    module Rule
+      class Match < Base
+        def initialize(pattern)
+          @pattern = pattern
+        end
+
+        def validate(target, position = [])
+          errors = []
+
+          unless target.match(@pattern)
+            errors << Error.new(position, "does not match #{@pattern.inspect}")
+          end
+
+          errors
+        end
+      end
+    end
+  end
+end

--- a/lib/schash/schema/rule/match.rb
+++ b/lib/schash/schema/rule/match.rb
@@ -9,7 +9,7 @@ module Schash
         def validate(target, position = [])
           errors = []
 
-          unless target.match(@pattern)
+          unless @pattern.match(target)
             errors << Error.new(position, "does not match #{@pattern.inspect}")
           end
 

--- a/spec/schash_spec.rb
+++ b/spec/schash_spec.rb
@@ -22,6 +22,8 @@ describe Schash::Validator do
           }),
           boolean: boolean,
           not_boolean: boolean,
+          match: match(/^pattern$/),
+          not_match: match(/^pattern$/)
         }
       }
     end
@@ -45,6 +47,8 @@ describe Schash::Validator do
             array_of_hash: [{}],
             boolean: true,
             not_boolean: "string",
+            match: "pattern",
+            not_match: "not match pattern"
           },
         })
 
@@ -85,6 +89,10 @@ describe Schash::Validator do
             ["data", "not_boolean"],
             "is not any of TrueClass, FalseClass",
           ],
+          [
+            ["data", "not_match"],
+            "does not match /^pattern$/",
+          ]
         ]
 
         expect(errors.size).to eq(expected.size)


### PR DESCRIPTION
Add `match` rule for validate string more preceisely using `Regexp#match`.
Validation example added in `README.md` and `schash_spec.rb`.
And more example below.

```
node.validate! do
  {
    mysqld: {
         port: match(/[1024-49151]/), # Only match string("1024"-"49151"), not numeric.
         bind_address: match(Resolv::IPv4::Regex)
    }
  }
end
```
