### PR TITLE
add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ validator.validate(invalid)
 # => [#<struct Schash::Schema::Error position=["nginx", "user"], message="is not String">, #<struct Schash::Schema::Error position=["nginx", "sites"], message="is not an array">, #<struct Schash::Schema::Error position=["nginx", "listen"], message="does not match /^(80|443)$/">]
 ```
 
+Validate may take an additional ```strict: true``` keyword argument (default is ```false```). In strict mode, entries in hashes which are not part of the schema will be considered as errors.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/schash/schema/rule/array_of.rb
+++ b/lib/schash/schema/rule/array_of.rb
@@ -10,7 +10,7 @@ module Schash
                   end
         end
 
-        def validate(target, position = [])
+        def validate(target, position = [], strict: false)
           errors = []
 
           unless target.is_a?(Array)
@@ -19,7 +19,7 @@ module Schash
           end
 
           errors += target.each_with_index.map do |t, i|
-            @rule.validate(t, position + [i])
+            @rule.validate(t, position + [i], strict: strict)
           end.flatten
 
           errors

--- a/lib/schash/schema/rule/hash.rb
+++ b/lib/schash/schema/rule/hash.rb
@@ -6,8 +6,8 @@ module Schash
           @schema_hash = schema_hash
         end
 
-        def validate(target, position = [])
-          @schema_hash.map do |key, rule|
+        def validate(target, position = [], strict: false)
+          errors = @schema_hash.map do |key, rule|
             if rule.is_a?(::Hash)
               rule = self.class.new(rule)
             end
@@ -17,13 +17,24 @@ module Schash
             end
 
             if found_key
-              rule.validate(target[found_key], position + [key.to_s])
+              rule.validate(target[found_key], position + [key.to_s], strict: strict)
             else
               unless rule.optional?
                 Error.new(position + [key.to_s], "is required but missing")
               end
             end
-          end.flatten.compact
+          end
+          if strict
+            target.each_key do |key|
+              found_key = [key.to_s, key.to_sym].find do |k|
+                @schema_hash.key?(k)
+              end
+              if !found_key
+                errors.append(Error.new(position + [key.to_s], "is not in schema"))
+              end
+            end
+          end
+          errors.flatten.compact
         end
       end
     end

--- a/lib/schash/schema/rule/match.rb
+++ b/lib/schash/schema/rule/match.rb
@@ -6,7 +6,7 @@ module Schash
           @pattern = pattern
         end
 
-        def validate(target, position = [])
+        def validate(target, position = [], strict: false)
           errors = []
 
           unless @pattern.match(target)

--- a/lib/schash/schema/rule/one_of_types.rb
+++ b/lib/schash/schema/rule/one_of_types.rb
@@ -6,7 +6,7 @@ module Schash
           @klasses = klasses
         end
 
-        def validate(target, position = [])
+        def validate(target, position = [], strict: false)
           match = @klasses.any? do |klass|
             target.is_a?(klass)
           end

--- a/lib/schash/schema/rule/optional.rb
+++ b/lib/schash/schema/rule/optional.rb
@@ -6,8 +6,8 @@ module Schash
           @rule = rule
         end
 
-        def validate(target, position = [])
-          @rule.validate(target, position)
+        def validate(target, position = [], strict: false)
+          @rule.validate(target, position, strict: strict)
         end
 
         def optional?

--- a/lib/schash/schema/rule/type.rb
+++ b/lib/schash/schema/rule/type.rb
@@ -6,7 +6,7 @@ module Schash
           @klass = klass
         end
 
-        def validate(target, position = [])
+        def validate(target, position = [], strict: false)
           errors = []
 
           unless target.is_a?(@klass)

--- a/lib/schash/validator.rb
+++ b/lib/schash/validator.rb
@@ -4,8 +4,8 @@ module Schash
       @validator = Schema::Rule::Hash.new(Schema::DSL.evaluate(&schema_block))
     end
 
-    def validate(target)
-      @validator.validate(target)
+    def validate(target, strict: false)
+      @validator.validate(target, strict: strict)
     end
   end
 end

--- a/spec/schash_spec.rb
+++ b/spec/schash_spec.rb
@@ -102,5 +102,104 @@ describe Schash::Validator do
         end
       end
     end
+    context "with valid data" do
+      it "returns no errors" do
+        errors = subject.validate({
+          data: {
+            string: "string",
+            not_string: "string",
+            words: [ "string" ],
+            not_array: [ "string" ],
+            required_missing: "string",
+            numeric: 1,
+            not_numeric: 1,
+            hash: {
+              required_missing: "string"
+            },
+            array_of_hash: [{required_missing: "string"}],
+            boolean: true,
+            not_boolean: true,
+            match: "pattern",
+            not_match: "pattern"
+          },
+        })
+
+        expected = []
+
+        expect(errors.size).to eq(expected.size)
+        errors.each_with_index do |error, i|
+          expect(error.position).to eq(expected[i][0])
+          expect(error.message).to  eq(expected[i][1])
+        end
+      end
+    end
+    context "with not strictly valid data and strict validation" do
+      it "returns errors" do
+        errors = subject.validate({
+          data: {
+            unexpected: "string",
+            string: "string",
+            not_string: "string",
+            words: [ "string" ],
+            not_array: [ "string" ],
+            required_missing: "string",
+            numeric: 1,
+            not_numeric: 1,
+            hash: {
+              required_missing: "string"
+            },
+            array_of_hash: [{required_missing: "string"}],
+            boolean: true,
+            not_boolean: true,
+            match: "pattern",
+            not_match: "pattern"
+          },
+        }, strict: true)
+
+        expected = [
+          [
+            ["data", "unexpected"],
+            "is not in schema",
+          ],
+        ]
+
+        expect(errors.size).to eq(expected.size)
+        errors.each_with_index do |error, i|
+          expect(error.position).to eq(expected[i][0])
+          expect(error.message).to  eq(expected[i][1])
+        end
+      end
+    end
+    context "with stricly valid data and strict validation" do
+      it "returns no errors" do
+        errors = subject.validate({
+          data: {
+            string: "string",
+            not_string: "string",
+            words: [ "string" ],
+            not_array: [ "string" ],
+            required_missing: "string",
+            numeric: 1,
+            not_numeric: 1,
+            hash: {
+              required_missing: "string"
+            },
+            array_of_hash: [{required_missing: "string"}],
+            boolean: true,
+            not_boolean: true,
+            match: "pattern",
+            not_match: "pattern"
+          },
+        }, strict: true)
+
+        expected = []
+
+        expect(errors.size).to eq(expected.size)
+        errors.each_with_index do |error, i|
+          expect(error.position).to eq(expected[i][0])
+          expect(error.message).to  eq(expected[i][1])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds a strict mode: validate may take an additional strict: true keyword argument (default is false). In strict mode, entries in hashes which are not part of the schema will be considered as errors.