### PR TITLE
Support optional hash

### DIFF
--- a/lib/schash/schema/dsl.rb
+++ b/lib/schash/schema/dsl.rb
@@ -17,8 +17,8 @@ module Schash
         Rule::Type.new(klass)
       end
 
-      def optional(rule)
-        Rule::Optional.new(rule)
+      def optional(schema)
+        Rule::Optional.new(schema)
       end
 
       def string

--- a/lib/schash/schema/rule/optional.rb
+++ b/lib/schash/schema/rule/optional.rb
@@ -3,7 +3,11 @@ module Schash
     module Rule
       class Optional < Base
         def initialize(rule)
-          @rule = rule
+          @rule = if rule.is_a?(::Hash)
+                    Rule::Hash.new(rule)
+                  else
+                    rule
+                  end
         end
 
         def validate(target, position = [])

--- a/spec/schash_spec.rb
+++ b/spec/schash_spec.rb
@@ -20,6 +20,9 @@ describe Schash::Validator do
           array_of_hash: array_of({
             required_missing: string,
           }),
+          optional_hash: optional({
+            required_missing: string,
+          }),
           boolean: boolean,
           not_boolean: boolean,
           match: match(/^pattern$/),
@@ -45,6 +48,7 @@ describe Schash::Validator do
             hash: {
             },
             array_of_hash: [{}],
+            optional_hash: {},
             boolean: true,
             not_boolean: "string",
             match: "pattern",
@@ -83,6 +87,10 @@ describe Schash::Validator do
           ],
           [
             ["data", "array_of_hash", 0, "required_missing"],
+            "is required but missing",
+          ],
+          [
+            ["data", "optional_hash", "required_missing"],
             "is required but missing",
           ],
           [


### PR DESCRIPTION
The current implementation raises an exception when given the following input for a schema and data.
But I think the users expect that the Hash structure is validated, not the exception.
Specifically, the former input should return no error and the latter input should return `[["data", "optional_hash", "test"], "is required but missing"]`.
The changes in this PR are to bring schash's behavior in line with its users' expectations.

schema:
```rb
{
  optional_hash: optional({
    test: string,
  }),
}
```

data:
```rb
{ optional_hash: { test: "test" } }
```

```rb
{ optional_hash: {} }
```

execption:

```
NoMethodError: undefined method `validate' for #<Hash:0xffffffffffffffff>
```

expectations:

```rb
[]
```

```rb
[[["data", "optional_hash", "test"], "is required but missing"]]
```